### PR TITLE
[feat]: Add preview tools

### DIFF
--- a/assets/themes/main.json
+++ b/assets/themes/main.json
@@ -36,11 +36,11 @@
   },
   "CTkCheckBox": {
     "corner_radius": 6,
-    "border_width": 3,
-    "fg_color": ["#3a7ebf", "#1f538d"],
+    "border_width": 2,
+    "fg_color": ["#3a7ebf", "#1a7ecf"],
     "border_color": ["#3E454A", "#949A9F"],
-    "hover_color": ["#325882", "#14375e"],
-    "checkmark_color": ["#DCE4EE", "gray90"],
+    "hover_color": ["#2f80d9", "#209bff"],
+    "checkmark_color": ["#ffffff", "#ffffff"],
     "text_color": ["gray14", "gray84"],
     "text_color_disabled": ["gray60", "gray45"]
   },

--- a/classes/mosaico.py
+++ b/classes/mosaico.py
@@ -20,6 +20,7 @@ class Mosaico():
       self.img = self.rgn()
     else:
       self.img = self.rgb()
+    self.soilless_img = None
     
   def __str__(self):
     return self.path, self.type
@@ -89,6 +90,10 @@ class Mosaico():
   
   def get_soilless_img(self, soil_points):
     mask = generate_mask_from_tile(self.path, soil_points)
-    
-    
-    return mask
+    image_array = np.array(self.img)
+    masked_img = np.zeros(image_array.shape, dtype=np.uint8)
+    masked_img[:, :, 0] = image_array[:, :, 0] * mask[:, :, 0]
+    masked_img[:, :, 1] = image_array[:, :, 1] * mask[:, :, 0]
+    masked_img[:, :, 2] = image_array[:, :, 2] * mask[:, :, 0]
+    self.soilless_img = Image.fromarray(masked_img)
+    return self.soilless_img, mask

--- a/components/previewTools.py
+++ b/components/previewTools.py
@@ -1,0 +1,42 @@
+import customtkinter as ctk
+from PIL import Image
+
+class previewTools(ctk.CTkFrame):
+  def __init__(self, parent, on_toggle_roi = None, on_toggle_remove_soil = None, on_save = None, **kwargs):
+    super().__init__(parent, **kwargs)
+    self.configure(fg_color="#000", corner_radius = 0)
+    # Parámetros
+    self.on_toggle_roi = on_toggle_roi
+    self.on_toggle_remove_soil = on_toggle_remove_soil
+    self.on_save = on_save
+    
+    # Componentes
+    self.check_show_roi = ctk.BooleanVar(value=True)
+    self.preview_roi = ctk.CTkCheckBox(self, text="Mostrar ROIs", variable=self.check_show_roi, command=self.handle_toggle_roi,onvalue=True, offvalue=False, height=5, font=("Consolas", 12), checkbox_height=16, checkbox_width=16, corner_radius= 0)
+    self.preview_roi.pack(side="left", fill="x", padx=5, pady=5)
+    
+    self.check_remove_soil = ctk.BooleanVar(value=True)
+    self.remove_soil = ctk.CTkCheckBox(self, text="Quitar suelo",variable=self.check_remove_soil,command=self.handle_toggle_remove_soil, onvalue=True, offvalue=False, height=5, font=("Consolas", 12), checkbox_height=16, checkbox_width=16, corner_radius= 0)
+    self.remove_soil.pack(side="left", fill="x", padx=5, pady=5)
+    
+    save_img = ctk.CTkImage(light_image=Image.open("assets/icons/save.png"), dark_image=Image.open("assets/icons/save.png"), size=(15, 15))
+    self.save_button = ctk.CTkButton(self, text="Guardar", image=save_img, command=self.save, height=16, width=50, font=("Consolas", 12), fg_color="#000", hover_color="#000")
+    self.save_button.pack(side="right", fill="x", padx=0, pady=0)
+
+  def get_roi(self):
+    return self.check_show_roi.get()
+  
+  def get_remove_soil(self):
+    return self.check_remove_soil.get()
+  
+  def handle_toggle_roi(self):
+    if self.on_toggle_roi is not None:
+      self.on_toggle_roi(value=self.check_show_roi.get())
+  
+  def handle_toggle_remove_soil(self):
+    if self.on_toggle_remove_soil is not None:
+      self.on_toggle_remove_soil()
+  
+  def save(self):
+    if self.on_save is not None:
+      self.on_save()


### PR DESCRIPTION
Se añade una barra bajo la imagen en previewRoi que permite activar o desactivar la visibilidad de los ROIs y la visibilidad del suelo, además incluye un botón para descargar la imagen de la vista previa. Además considerando que la función está incluida dentro de previewTools, se elimina el checkbox sowRois de previewRoi.py